### PR TITLE
Fix register group creator

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -567,10 +567,13 @@ def register():
             
             if family_group:
                 user.group_id = family_group.id
-                if group_action == 'create':
-                    family_group.created_by = user.id
-            
+
             db.session.add(user)
+            db.session.flush()  # Flush to generate user ID before using it
+
+            if family_group and group_action == 'create':
+                family_group.created_by = user.id
+
             db.session.commit()
             
             if group_action == 'create' and family_group:


### PR DESCRIPTION
## Summary
- update register route to set `family_group.created_by` after flushing the new user
- comment that flush is needed to generate `user.id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d345a8ebc832886697bba1269e6a2